### PR TITLE
아리랑 뉴스 API 클라이언트 구현

### DIFF
--- a/src/main/java/com/surfit/backend/domain/news/client/ArirangNewsClient.java
+++ b/src/main/java/com/surfit/backend/domain/news/client/ArirangNewsClient.java
@@ -1,0 +1,73 @@
+package com.surfit.backend.domain.news.client;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import com.surfit.backend.domain.news.dto.ArirangNewsItem;
+import com.surfit.backend.domain.news.dto.ArirangNewsResponse;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class ArirangNewsClient {
+
+	private final RestClient restClient;
+	private final String apiKey;
+	private static final int PAGE_SIZE = 100;
+	private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+	public ArirangNewsClient(
+		RestClient.Builder restClientBuilder,
+		@Value("${arirang.api.base-url}") String baseUrl,
+		@Value("${arirang.api.api-key}") String apiKey) {
+		this.restClient = restClientBuilder.baseUrl(baseUrl).build();
+		this.apiKey = apiKey;
+	}
+
+	public List<ArirangNewsItem> fetchTodayNews() {
+		List<ArirangNewsItem> result = new ArrayList<>();
+		String today = LocalDate.now().format(DATE_FORMATTER);
+		int currentPage = 0;
+
+		while (true) {
+			int page = currentPage;
+			ArirangNewsResponse response = restClient.get()
+				.uri(uriBuilder -> uriBuilder
+					.queryParam("serviceKey", apiKey)
+					.queryParam("pageNo", page)
+					.queryParam("numOfRows", PAGE_SIZE)
+					.build())
+				.retrieve()
+				.body(ArirangNewsResponse.class);
+
+			if (response == null || response.items() == null || response.items().isEmpty()) {
+				break;
+			}
+
+			boolean hasOlderNews = false;
+			for (ArirangNewsItem item : response.items()) {
+				if (item.broadcastDate().startsWith(today)) {
+					result.add(item);
+				} else {
+					hasOlderNews = true;
+				}
+			}
+
+			if (hasOlderNews) {
+				break;
+			}
+
+			currentPage++;
+		}
+
+		log.info("{} 기사 {}건 수집 완료", today, result.size());
+		return result;
+	}
+}

--- a/src/main/java/com/surfit/backend/domain/news/dto/ArirangNewsItem.java
+++ b/src/main/java/com/surfit/backend/domain/news/dto/ArirangNewsItem.java
@@ -1,0 +1,13 @@
+package com.surfit.backend.domain.news.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record ArirangNewsItem(
+	String title,
+	String content,
+	@JsonProperty("news_url") String newsUrl,
+	@JsonProperty("thum_url") String thumUrl,
+	@JsonProperty("broadcast_date") String broadcastDate
+) {
+
+}

--- a/src/main/java/com/surfit/backend/domain/news/dto/ArirangNewsResponse.java
+++ b/src/main/java/com/surfit/backend/domain/news/dto/ArirangNewsResponse.java
@@ -1,0 +1,13 @@
+package com.surfit.backend.domain.news.dto;
+
+import java.util.List;
+
+public record ArirangNewsResponse(
+	int resultCode,
+	String resultMsg,
+	int numOfRows,
+	int pageNo,
+	int totalCount,
+	List<ArirangNewsItem> items
+) {
+}

--- a/src/main/java/com/surfit/backend/global/config/RestClientConfig.java
+++ b/src/main/java/com/surfit/backend/global/config/RestClientConfig.java
@@ -1,0 +1,14 @@
+package com.surfit.backend.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class RestClientConfig {
+
+	@Bean
+	public RestClient.Builder restClientBuilder() {
+		return RestClient.builder();
+	}
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -21,3 +21,9 @@ spring:
     hibernate:
       ddl-auto: update
     show-sql: true
+
+arirang:
+  api:
+    base-url: ${ARIRANG_API_BASE_URL}
+    api-key: ${ARIRANG_API_KEY}
+

--- a/src/test/java/com/surfit/backend/domain/news/client/ArirangNewsClientTest.java
+++ b/src/test/java/com/surfit/backend/domain/news/client/ArirangNewsClientTest.java
@@ -1,0 +1,27 @@
+package com.surfit.backend.domain.news.client;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.surfit.backend.domain.news.dto.ArirangNewsItem;
+
+@SpringBootTest
+public class ArirangNewsClientTest {
+
+	@Autowired
+	private ArirangNewsClient arirangNewsClient;
+
+	@Test
+	void 오늘_뉴스_수() {
+		List<ArirangNewsItem> items = arirangNewsClient.fetchTodayNews();
+
+		assertThat(items).isNotNull();
+		System.out.println("수집된 기사 수: " + items.size());
+		items.forEach(item -> System.out.println(item.title()));
+	}
+}


### PR DESCRIPTION
## 📝 PR 설명

- 아리랑 뉴스 API를 호출해 당일! 기사 목록을 수집하는 클라이언트 구현

## 🛠️ 작업 상세 내용

- RestClient 빈 등록 및 Arirang API 환경변수(`base-url`, `api-key`) 설정 추가
- API 응답 역직렬화를 위한 DTO 구현 (`ArirangNewsItem`, `ArirangNewsResponse`)
- 당일 기사만 필터링하는 페이지네이션 수집 로직 구현 (`ArirangNewsClient`)

## 🧪 테스트 여부 및 확인 내용

- @SpringBootTest 통합 테스트 작성 및 실제 API 호출 확인
- 당일 기사 정상 수집 확인

## 📸 스크린샷 (선택)

## 💬 기타 / 참고사항

## 🔗 연관 이슈

- Closes #8
- 해당 PR이 머지되면 이슈가 자동으로 닫힙니다.