### PR TITLE
feat: LLM 추상화 레이어 및 Gemini 구현체 추가

### DIFF
--- a/src/main/java/com/surfit/backend/domain/keyword/dto/KeywordPayload.java
+++ b/src/main/java/com/surfit/backend/domain/keyword/dto/KeywordPayload.java
@@ -1,0 +1,12 @@
+package com.surfit.backend.domain.keyword.dto;
+
+public record KeywordPayload(
+	String primaryKeyword,
+	String fallbackKeyword,
+	String category,
+	String newsTitle,
+	String newsContent,
+	String newsUrl,
+	String broadcastDate
+) {
+}

--- a/src/main/java/com/surfit/backend/global/llm/LlmClient.java
+++ b/src/main/java/com/surfit/backend/global/llm/LlmClient.java
@@ -1,0 +1,5 @@
+package com.surfit.backend.global.llm;
+
+public interface LlmClient {
+	String complete(String systemPrompt, String userPrompt);
+}

--- a/src/main/java/com/surfit/backend/global/llm/gemini/GeminiLlmClient.java
+++ b/src/main/java/com/surfit/backend/global/llm/gemini/GeminiLlmClient.java
@@ -1,0 +1,42 @@
+package com.surfit.backend.global.llm.gemini;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import com.surfit.backend.global.llm.LlmClient;
+import com.surfit.backend.global.llm.gemini.dto.GeminiRequest;
+import com.surfit.backend.global.llm.gemini.dto.GeminiResponse;
+
+@Component
+public class GeminiLlmClient implements LlmClient {
+
+	private final RestClient restClient;
+
+	public GeminiLlmClient(
+		RestClient.Builder restClientBuilder,
+		@Value("${gemini.api.base-url}") String baseUrl,
+		@Value("${gemini.api.model}") String model,
+		@Value("${gemini.api.api-key}") String apiKey) {
+		this.restClient = restClientBuilder
+			.baseUrl(baseUrl + "/" + model + ":generateContent?key=" + apiKey)
+			.build();
+	}
+
+	@Override
+	public String complete(String systemPrompt, String userPrompt) {
+		GeminiRequest request = new GeminiRequest(
+			new GeminiRequest.Content(List.of(new GeminiRequest.Part(systemPrompt))),
+			List.of(new GeminiRequest.Content(List.of(new GeminiRequest.Part(userPrompt))))
+		);
+
+		GeminiResponse response = restClient.post()
+			.body(request)
+			.retrieve()
+			.body(GeminiResponse.class);
+
+		return response.candidates().get(0).content().parts().get(0).text();
+	}
+}

--- a/src/main/java/com/surfit/backend/global/llm/gemini/dto/GeminiRequest.java
+++ b/src/main/java/com/surfit/backend/global/llm/gemini/dto/GeminiRequest.java
@@ -1,0 +1,16 @@
+package com.surfit.backend.global.llm.gemini.dto;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record GeminiRequest(
+	@JsonProperty("system_instruction") Content systemInstruction,
+	List<Content> contents
+) {
+	public record Content(List<Part> parts) {
+	}
+
+	public record Part(String text) {
+	}
+}

--- a/src/main/java/com/surfit/backend/global/llm/gemini/dto/GeminiResponse.java
+++ b/src/main/java/com/surfit/backend/global/llm/gemini/dto/GeminiResponse.java
@@ -1,0 +1,14 @@
+package com.surfit.backend.global.llm.gemini.dto;
+
+import java.util.List;
+
+public record GeminiResponse(List<Candidate> candidates) {
+	public record Candidate(Content content) {
+	}
+
+	public record Content(List<Part> parts) {
+	}
+
+	public record Part(String text) {
+	}
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -27,3 +27,8 @@ arirang:
     base-url: ${ARIRANG_API_BASE_URL}
     api-key: ${ARIRANG_API_KEY}
 
+gemini:
+  api:
+    base-url: https://generativelanguage.googleapis.com/v1beta/models
+    model: gemini-3-flash-preview
+    api-key: ${GEMINI_API_KEY}

--- a/src/test/java/com/surfit/backend/global/llm/GeminiLlmClientTest.java
+++ b/src/test/java/com/surfit/backend/global/llm/GeminiLlmClientTest.java
@@ -1,0 +1,27 @@
+package com.surfit.backend.global.llm;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.surfit.backend.global.llm.gemini.GeminiLlmClient;
+
+@SpringBootTest
+public class GeminiLlmClientTest {
+
+	@Autowired
+	private GeminiLlmClient geminiLlmClient;
+
+	@Test
+	void 제미나이_호출_테스트() {
+		String response = geminiLlmClient.complete(
+			"You are a helpful assitant. Answer in one sentence.",
+			"What is the capital of South Korea?"
+		);
+
+		System.out.println("제미나이 응답: " + response);
+		assertThat(response).isNotBlank();
+	}
+}


### PR DESCRIPTION
## 📝 PR 설명

- LLM 추상화 인터페이스(`LlmClient`) 정의 및 Gemini 구현체 추가

## 🛠️ 작업 상세 내용

- `LlmClient` 인터페이스 정의 (`global/llm`) — 재표형과 공동 사용
- `GeminiLlmClient` 구현체 추가 — `gemini-3-flash-preview` 모델 사용
- `GeminiRequest` / `GeminiResponse` DTO 정의 — Gemini API 요청/응답 구조 매핑
- `KeywordPayload` DTO 추가 — LLM 키워드 추출 결과 전달용 <----------- 재표형에게 전달하는 DTO 확인 부탁
- `application.yaml`에 Gemini API 설정 추가 (환경변수 파일 업데이트 필요!!!!!!!!!!!!!!)

## 🧪 테스트 여부 및 확인 내용

- `GeminiLlmClientTest` 통합 테스트 통과 (Gemini API 실제 호출 확인)
- 테스트 하고 싶을 시 실행 -> 구성 편집에 들어가서 아래 체크 두 개 하고 .env 파일 추가
<img width="798" height="653" alt="스크린샷 2026-04-08 오후 11 21 42" src="https://github.com/user-attachments/assets/a7719a6d-f04f-4004-bfc4-44fbd435f100" />

## 💬 기타 / 참고사항

- 재표형은 지식 카드 생성 시 위의 구현한 GeminiLlmClient 사용하면 될 듯 함 <- 요청과 응답 record는 형식이니 참고해서 그대로 활용
- 우선은 저 제미나이 무료 버전으로 카드 생성 프롬프트까지 진행하고 나중에 유료 모델로 변경하는 것으로
- KeywordPayload는 우선 저렇게 가정하고 개발하는 것으로

## 🔗 연관 이슈

- Closes #9 
- KeywordExtractionService 구현 (카테고리 분류 → 키워드 추출)은 다음 이슈에서 구현하는 것으로 진행
- 해당 PR이 머지되면 이슈가 자동으로 닫힙니다.