### PR TITLE
feat: LLM 기반 뉴스 키워드 추출 기능 구현

### DIFF
--- a/docs/Javadoc_가이드.md
+++ b/docs/Javadoc_가이드.md
@@ -1,0 +1,88 @@
+# Javadoc 가이드
+
+코드 가독성과 팀원 팔로업을 위해 주요 메서드에 Javadoc을 작성합니다.
+IntelliJ에서 메서드에 마우스를 올리면 팝업으로 설명이 표시됩니다.
+
+---
+
+### 작성 대상
+
+| 대상                        | 작성 여부              |
+|:--------------------------|:-------------------|
+| 인터페이스 `public` 메서드        | ✅ 필수               |
+| 서비스 레이어 `public` 메서드      | ✅ 필수               |
+| 외부 API 클라이언트 `public` 메서드 | ✅ 필수               |
+| `@Override` 구현체 메서드       | ❌ 생략 (인터페이스에서 상속됨) |
+| DTO 필드                    | ❌ 생략 (필드명으로 충분)    |
+| `private` 메서드             | ❌ 생략               |
+
+---
+
+### 기본 형식
+
+파라미터, 반환값, 예외가 없는 경우 해당 태그는 생략합니다.
+
+```java
+/**
+ * 한 줄 기능 설명
+ *
+ * @param 파라미터명 설명
+ * @return 반환값 설명
+ * @throws 예외 발생 조건
+ */
+```
+
+---
+
+### 작성 예시
+
+#### 인터페이스
+
+```java
+public interface LlmClient {
+
+	/**
+	 * LLM에 시스템 프롬프트와 사용자 프롬프트를 전달하고 생성된 텍스트를 반환한다.
+	 *
+	 * @param systemPrompt LLM의 역할 및 출력 형식을 지시하는 고정 프롬프트
+	 * @param userPrompt   실제 분석할 데이터 또는 질문
+	 * @return LLM이 생성한 텍스트 응답
+	 */
+	String complete(String systemPrompt, String userPrompt);
+}
+```
+
+#### 구현체 — `@Override` 메서드는 생략
+
+```java
+
+@Component
+public class GeminiLlmClient implements LlmClient {
+
+	@Override
+	public String complete(String systemPrompt, String userPrompt) {
+		// 구현 내용
+	}
+}
+```
+
+#### 서비스
+
+```java
+
+@Service
+public class KeywordExtractionService {
+
+	/**
+	 * 오늘 날짜 뉴스를 수집하고 LLM으로 키워드를 추출해 KeywordPayload 리스트로 반환한다.
+	 *
+	 * @return 키워드 및 뉴스 메타데이터가 담긴 KeywordPayload 리스트
+	 * @throws Exception LLM 호출 실패 또는 JSON 파싱 오류 시
+	 */
+	public List<KeywordPayload> extractKeywords() throws Exception {
+		// 구현 내용
+	}
+}
+```
+
+---

--- a/src/main/java/com/surfit/backend/domain/keyword/dto/KeywordPayload.java
+++ b/src/main/java/com/surfit/backend/domain/keyword/dto/KeywordPayload.java
@@ -7,6 +7,7 @@ public record KeywordPayload(
 	String newsTitle,
 	String newsContent,
 	String newsUrl,
+	String curationReason,
 	String broadcastDate
 ) {
 }

--- a/src/main/java/com/surfit/backend/domain/keyword/service/KeywordExtractionService.java
+++ b/src/main/java/com/surfit/backend/domain/keyword/service/KeywordExtractionService.java
@@ -1,0 +1,93 @@
+package com.surfit.backend.domain.keyword.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.surfit.backend.domain.keyword.dto.KeywordPayload;
+import com.surfit.backend.domain.news.client.ArirangNewsClient;
+import com.surfit.backend.domain.news.dto.ArirangNewsItem;
+import com.surfit.backend.global.llm.LlmClient;
+
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
+
+@Service
+public class KeywordExtractionService {
+
+	private static final String SYSTEM_PROMPT = """
+		당신은 지식 큐레이션 서비스 'Surf'의 핵심 분석 엔진입니다.
+		제공된 뉴스 목록에서 지식 카드화하기 적합한 기사를 골라 분석 결과를 JSON 배열로 반환하세요.
+		
+		[분석 지침]
+		1. primaryKeyword: 기사의 핵심 주제 중 위키피디아에서 학술적/정보적 정의를 찾을 수 있는 구체적인 영문 명사.
+		2. fallbackKeyword: primaryKeyword 검색 실패 시 사용할 수 있는 상위 개념의 일반 영문 명사.
+		3. category: [Economy, Tech, Science, Politics, Society] 중 하나로 분류.
+		4. curationReason: 이 뉴스가 왜 지식적으로 가치 있는지 한국어 1문장으로 설명.
+		
+		[출력 형식]
+		반드시 아래 JSON 구조만 반환하세요. (마크다운 코드블록 없이 순수 JSON만)
+		[
+		  {
+			"newsUrl": "입력받은 기사의 newsUrl 그대로",
+			"primaryKeyword": "...",
+			"fallbackKeyword": "...",
+			"category": "...",
+			"curationReason": "..."
+		  }
+		]
+		""";
+	private final ArirangNewsClient arirangNewsClient;
+	private final LlmClient llmClient;
+	private final ObjectMapper objectMapper;
+
+	public KeywordExtractionService(
+		ArirangNewsClient arirangNewsClient,
+		LlmClient llmClient,
+		ObjectMapper objectMapper) {
+		this.arirangNewsClient = arirangNewsClient;
+		this.llmClient = llmClient;
+		this.objectMapper = objectMapper;
+	}
+
+	public List<KeywordPayload> extractKeywords() throws Exception {
+		List<ArirangNewsItem> newsList = arirangNewsClient.fetchTodayNews();
+
+		String newsJson = objectMapper.writeValueAsString(newsList);
+		String userPrompt = "아래 뉴스 목록을 분석해주세요:\n" + newsJson;
+
+		String llmResponse = llmClient.complete(SYSTEM_PROMPT, userPrompt);
+
+		List<LlmResult> llmResults = objectMapper.readValue(llmResponse, new TypeReference<List<LlmResult>>() {
+		});
+
+		return llmResults.stream()
+			.map(result -> {
+				ArirangNewsItem news = newsList.stream()
+					.filter(n -> n.newsUrl().equals(result.newsUrl()))
+					.findFirst()
+					.orElseThrow();
+				return new KeywordPayload(
+					result.primaryKeyword(),
+					result.fallbackKeyword(),
+					result.category(),
+					news.title(),
+					news.content(),
+					news.newsUrl(),
+					result.curationReason(),
+					news.broadcastDate()
+				);
+			})
+			.toList();
+	}
+
+	// 내부 record, 위 메소드에서만 사용
+	private record LlmResult(
+		String newsUrl,
+		String primaryKeyword,
+		String fallbackKeyword,
+		String category,
+		String curationReason
+	) {
+	}
+}

--- a/src/main/java/com/surfit/backend/domain/keyword/service/KeywordExtractionService.java
+++ b/src/main/java/com/surfit/backend/domain/keyword/service/KeywordExtractionService.java
@@ -50,6 +50,13 @@ public class KeywordExtractionService {
 		this.objectMapper = objectMapper;
 	}
 
+	/**
+	 * 오늘 날짜 뉴스를 수집하고 LLM으로 키워드 추출 및 카테고리 선별을 하여 KeywordPayload 리스트로 반환
+	 * LLM이 지식카드화 적합한 기사를 선별하고 primaryKeyword, fallbackKeyword, category, curationReason을 추출
+	 *
+	 * @return 키워드 및 뉴스 메타데이터가 담긴 KeywordPayload 리스트
+	 * @throws Exception LLM 호출 실패 또는 JSON 파싱 오류 시
+	 */
 	public List<KeywordPayload> extractKeywords() throws Exception {
 		List<ArirangNewsItem> newsList = arirangNewsClient.fetchTodayNews();
 

--- a/src/main/java/com/surfit/backend/domain/news/client/ArirangNewsClient.java
+++ b/src/main/java/com/surfit/backend/domain/news/client/ArirangNewsClient.java
@@ -31,6 +31,12 @@ public class ArirangNewsClient {
 		this.apiKey = apiKey;
 	}
 
+	/**
+	 * 아리랑 뉴스 API에서 오늘 날짜의 기사를 전부 수집해 반환
+	 * 페이지네이션을 반복하며 오늘 날짜가 아닌 기사가 나오면 수집을 중단
+	 *
+	 * @return 오늘 날짜 기사 리스트
+	 */
 	public List<ArirangNewsItem> fetchTodayNews() {
 		List<ArirangNewsItem> result = new ArrayList<>();
 		String today = LocalDate.now().format(DATE_FORMATTER);

--- a/src/main/java/com/surfit/backend/global/llm/LlmClient.java
+++ b/src/main/java/com/surfit/backend/global/llm/LlmClient.java
@@ -1,5 +1,13 @@
 package com.surfit.backend.global.llm;
 
 public interface LlmClient {
+
+	/**
+	 * LLM에 시스템 프롬프트와 사용자 프롬프트를 전달하고 생성된 텍스트를 반환한다.
+	 *
+	 * @param systemPrompt LLM의 역할 및 출력 형식을 지시하는 고정 프롬프트
+	 * @param userPrompt   실제 분석할 데이터 또는 질문
+	 * @return LLM이 생성한 텍스트 응답
+	 */
 	String complete(String systemPrompt, String userPrompt);
 }

--- a/src/test/java/com/surfit/backend/domain/keyword/service/KeywordExtractionServiceTest.java
+++ b/src/test/java/com/surfit/backend/domain/keyword/service/KeywordExtractionServiceTest.java
@@ -1,0 +1,36 @@
+package com.surfit.backend.domain.keyword.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.surfit.backend.domain.keyword.dto.KeywordPayload;
+
+@SpringBootTest
+public class KeywordExtractionServiceTest {
+
+	@Autowired
+	private KeywordExtractionService keywordExtractionService;
+
+	@Test
+	void 키워드_추출_테스트() throws Exception {
+		List<KeywordPayload> result = keywordExtractionService.extractKeywords();
+
+		System.out.println("추출된 키워드 수: " + result.size());
+		result.forEach(payload -> {
+			System.out.println("=====");
+			System.out.println("제목: " + payload.newsTitle());
+			System.out.println("primaryKeyword: " + payload.primaryKeyword());
+			System.out.println("fallbackKeyword: " + payload.fallbackKeyword());
+			System.out.println("category: " + payload.category());
+			System.out.println("curationReason: " + payload.curationReason());
+		});
+
+		assertThat(result).isNotEmpty();
+		assertThat(result.get(0).primaryKeyword()).isNotBlank();
+	}
+}


### PR DESCRIPTION
## 📝 PR 설명

- 아리랑 뉴스 API로 수집한 뉴스를 LLM에 전달해 키워드 및 카테고리, 추출 이유를 추출하는 서비스 구현

## 🛠️ 작업 상세 내용

- `KeywordPayload` DTO에 `curationReason` 필드 추가 (LLM 해당 뉴스 키워드 추출 선정 이유) <----- 이거 재표형 체크해서 구현하길 바람
- `KeywordExtractionService` 구현 — 뉴스 목록 수집 → LLM 호출 → `KeywordPayload` 리스트 반환
- `LlmResult` 내부 record로 LLM 응답 JSON 파싱 처리
- `KeywordExtractionServiceTest` 통합 테스트 작성
- 각 메소드 위에 원활한 팔로업을 위해 설명 주석 추가

## 🧪 테스트 여부 및 확인 내용

- `KeywordExtractionServiceTest` 통합 테스트 통과
- 오늘 날짜 기사 41건 수집 후 LLM이 8건 선별, 키워드/카테고리/선정 이유 정상 추출 확인

## 📸 스크린샷 (선택)

## 💬 기타 / 참고사항

- 재표형 참고: `KeywordPayload`에 `curationReason` 필드 추가됨. 이 부분 체크!!! 나중에 어떤 이유로 이걸 추출 했는지 확인하기 위함 관리자 페이즈 등에서?
- 이후 재표형이 지식 카드 생성시에도 LlmClient 인터페이스를 활용하여 일단 사용하면 될 듯 함 <- 나중에 기능 별로 LLM 모델을 나눠야할 시에는 @Qualifier로 사용 모델 분리하는 방향으로
- `LlmClient` 인터페이스로 사용

## 🔗 연관 이슈

- Closes #15
- 해당 PR이 머지되면 이슈가 자동으로 닫힙니다.